### PR TITLE
Don't restrict the GROMACS version options

### DIFF
--- a/utilities/cli.py
+++ b/utilities/cli.py
@@ -112,7 +112,6 @@ class GromacsCLI(CLI):
         Seting up command line options with all available choices for each option
         '''
         self.parser.add_argument('--gromacs', type=str, default=config.DEFAULT_GROMACS_VERSION,
-                                 choices=['2019.2', '2020.1', '2020.2', '2020.3'],
                                  help='GROMACS version (DEFAULT: {0}).'.format(config.DEFAULT_GROMACS_VERSION))
 
         # TODO: add option to accept fftw container as input


### PR DESCRIPTION
This was an artificial barrier to using this script in bioexcel/gromacs-docker. When a newer version is wanted there, it would have to be first added here, which serves no purpose.