### PR TITLE
change GMX_GPU option to CUDA, not ON

### DIFF
--- a/container/apps.py
+++ b/container/apps.py
@@ -233,7 +233,7 @@ class Gromacs:
         # cuda, regtest, double
         for (option, enabled) in zip(['cuda', 'regtest', 'double'], [args.cuda, args.regtest, args.double]):
             if enabled:
-                gromacs_cmake_opts = gromacs_cmake_opts.replace('$' + option + '$', 'ON')
+                gromacs_cmake_opts = gromacs_cmake_opts.replace('$' + option + '$', 'CUDA')
             else:
                 gromacs_cmake_opts = gromacs_cmake_opts.replace('$' + option + '$', 'OFF')
 


### PR DESCRIPTION
For GROMACS 2021 we need to specify the GPU system, not just ON/OFF for GMX_GPU.

Needs to be either OFF, CUDA, OpenCL, or SYCL.